### PR TITLE
Support IDictionary

### DIFF
--- a/ObjectComparator.Tests/CompareObjectsTests.cs
+++ b/ObjectComparator.Tests/CompareObjectsTests.cs
@@ -883,5 +883,51 @@ namespace ObjectsComparator.Tests
                 .Be(new Distinction("Dictionary<String, String>[AnotherKey]", "Value", "AnotherValue"));
         }
 
+        [Test]
+        public void CompareIDictionaryProperty()
+        {
+            var exp = new Library2
+            {
+                Books = new Dictionary<string, Book>
+                {
+                    ["hobbit"] = new() { Pages = 1000, Text = "hobbit Text" },
+                }
+            };
+
+            var act = new Library2
+            {
+                Books = new Dictionary<string, Book>
+                {
+                    ["hobbit"] = new() { Pages = 1, Text = "hobbit Text" },
+                }
+            };
+
+            var result = exp.DeeplyEquals(act);
+            var expectedDistinctionsCollection = DeepEqualityResult.Create(new[]
+            {
+                new Distinction("Library.Books[hobbit].Pages", 1000, 1),
+            });
+
+            CollectionAssert.AreEquivalent(result, expectedDistinctionsCollection);
+        }
+
+        [Test]
+        public void CompareIDictionaryImplementation()
+        {
+            var firstDictionary = new StringDictionary
+            {
+                {"Key", "Value"},
+                {"AnotherKey", "Value"},
+            };
+
+            var secondDictionary = new StringDictionary
+            {
+                {"Key", "Value"},
+                {"AnotherKey", "AnotherValue"},
+            };
+
+            firstDictionary.DeeplyEquals(secondDictionary)[0].Should()
+                .Be(new Distinction("StringDictionary[AnotherKey]", "Value", "AnotherValue"));
+        }
     }
 }

--- a/ObjectComparator.Tests/TestModels/Library.cs
+++ b/ObjectComparator.Tests/TestModels/Library.cs
@@ -6,4 +6,9 @@ namespace ObjectsComparator.Tests.TestModels
     {
         public Dictionary<string, Book> Books { get; set; } = new Dictionary<string, Book>();
     }
+
+    internal class Library2
+    {
+        public IDictionary<string, Book> Books { get; set; } = new Dictionary<string, Book>();
+    }
 }

--- a/ObjectComparator.Tests/TestModels/StringDictionary.cs
+++ b/ObjectComparator.Tests/TestModels/StringDictionary.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ObjectsComparator.Tests.TestModels
+{
+    internal class StringDictionary : IDictionary<string, string>
+    {
+        private readonly Dictionary<string, string> _dictionary = new();
+
+        public string this[string key]
+        {
+            get => _dictionary[key];
+            set => _dictionary[key] = value;
+        }
+
+        public int Count => _dictionary.Count;
+
+        public bool TryGetValue(string key, [MaybeNullWhen(false)] out string value) => _dictionary.TryGetValue(key, out value);
+
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => _dictionary.GetEnumerator();
+
+        public void Add(string key, string value) => _dictionary.Add(key, value);
+
+        public ICollection<string> Keys => throw new System.NotImplementedException();
+        public ICollection<string> Values => throw new System.NotImplementedException();
+        public bool IsReadOnly => throw new System.NotImplementedException();
+
+        public void Add(KeyValuePair<string, string> item) => throw new System.NotImplementedException();
+        public void Clear() => throw new System.NotImplementedException();
+        public bool Contains(KeyValuePair<string, string> item) => throw new System.NotImplementedException();
+        public bool ContainsKey(string key) => throw new System.NotImplementedException();
+        public void CopyTo(KeyValuePair<string, string>[] array, int arrayIndex) => throw new System.NotImplementedException();
+        public bool Remove(string key) => throw new System.NotImplementedException();
+        public bool Remove(KeyValuePair<string, string> item) => throw new System.NotImplementedException();
+        IEnumerator IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
+    }
+}


### PR DESCRIPTION
This patch adds support for the IDictionary<,> interface.

The current ObjectComparator only supports Dictionary<,> as a dictionary type.
The ObjectComparator causes errors when comparing other dictionary types that implement IDictionary<,> and properties of type IDictionary<,>.
This patch fixes them.