### PR TITLE
Improve IEnumerable<> support

### DIFF
--- a/ObjectComparator.Tests/CompareObjectsTests.cs
+++ b/ObjectComparator.Tests/CompareObjectsTests.cs
@@ -930,5 +930,44 @@ namespace ObjectsComparator.Tests
                 .Be(new Distinction("StringDictionary[AnotherKey]", "Value", "AnotherValue"));
         }
 
+        [Test]
+        public void CompareIEnumerableProperty()
+        {
+            var act = new BuildingEnumerable
+            {
+                Address = "NY, First Street",
+                ListOfAppNumbers = new[] { 32, 25, 14, 89 }
+            };
+
+            var exp = new BuildingEnumerable
+            {
+                Address = "NY, First Street",
+                ListOfAppNumbers = new[] { 555, 25, 14, 89 }
+            };
+
+            exp.DeeplyEquals(act)[0].Should()
+                .Be(new Distinction("BuildingEnumerable.ListOfAppNumbers[0]", 555, 32));
+        }
+
+        [Test]
+        public void CompareIEnumerableImplementation()
+        {
+            var act = new StringList() { "A", "B" };
+            var exp = new StringList() { "B", "C" };
+
+            exp.DeeplyEquals(act)[0].Should()
+                .Be(new Distinction("StringList[0]", "B", "A"));
+        }
+
+        [Test]
+        public void CompareDifferentIEnumerableTypes()
+        {
+            var numbers = new[] { 1, 2, 3 };
+            var act = numbers.Skip(1);
+            var exp = numbers;
+
+            exp.DeeplyEquals(act)[0].Should()
+                .Be(new Distinction("Property \"IEnumerable<Int32>\": Collection has different length", 2, 3));
+        }
     }
 }

--- a/ObjectComparator.Tests/TestModels/BuildingEnumerable.cs
+++ b/ObjectComparator.Tests/TestModels/BuildingEnumerable.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace ObjectsComparator.Tests.TestModels
+{
+    internal class BuildingEnumerable
+    {
+        public string Address { get; set; }
+
+        public IEnumerable<int> ListOfAppNumbers { get; set; }
+    }
+}

--- a/ObjectComparator.Tests/TestModels/StringList.cs
+++ b/ObjectComparator.Tests/TestModels/StringList.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ObjectsComparator.Tests.TestModels
+{
+    public class StringList : IEnumerable<string>
+    {
+        private readonly List<string> _list = new();
+
+        public void Add(string item) => _list.Add(item);
+
+        public IEnumerator<string> GetEnumerator() => _list.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/ObjectComparator/Comparator/Comparator.cs
+++ b/ObjectComparator/Comparator/Comparator.cs
@@ -37,8 +37,8 @@ public sealed class Comparator
         var typeName = type.ToFriendlyTypeName();
         if (type != actualType)
         {
-            const string message = "Types are different";
-            return DeepEqualityResult.Create(new Distinction(message, typeName, actualType.ToFriendlyTypeName()));
+            type = typeof(T);
+            typeName = type.ToFriendlyTypeName();
         }
 
         if (expected != null && actual == null || expected == null && actual != null)


### PR DESCRIPTION
This PR improves comparisons involving implementations of IEnumerable<> in two scenarios. 

1. **Comparing instances of the same Implementation of IEnumerable<>**

The current implementation of ObjectComparator throws an `ArgumentNullException` when comparing instances of `StringList` defined as follows.
```csharp
public class StringList : IEnumerable<string>
```
This PR fixes this issue.

2. **Comparing different types implementing IEnumerable<>**

The current version reports the type difference when comparing an `int[]` and an `IEnumerable<int>` as follows.
```csharp
var numbers = new[] { 1, 2, 3 };
var act = numbers.Skip(1);
var exp = numbers;

string result = exp.DeeplyEquals(act); 
/*
Path: "Types are different":
Expected Value :Int32[]
Actually Value :ListPartition<Int32>
*/
``` 
In this case, I prefer to ignore the difference in the actual types and focus on the difference in their lengths.
This PR modifies the comparison to achieve this result.
```csharp
Path: "Property "IEnumerable<Int32>": Collection has different length":
Expected Value :2
Actually Value :3
```