### PR TITLE
Fix InvalidOperationException in comparing collections as `object`

### DIFF
--- a/ObjectComparator.Tests/CompareObjectsTests.cs
+++ b/ObjectComparator.Tests/CompareObjectsTests.cs
@@ -969,5 +969,34 @@ namespace ObjectsComparator.Tests
             exp.DeeplyEquals(act)[0].Should()
                 .Be(new Distinction("Property \"IEnumerable<Int32>\": Collection has different length", 2, 3));
         }
+
+        [Test]
+        public void CompareIEnumerableImplementationAsObject()
+        {
+            object act = new StringList() { "A", "B" };
+            object exp = new StringList() { "B", "C" };
+
+            exp.DeeplyEquals(act)[0].Should()
+                .Be(new Distinction("StringList[0]", "B", "A"));
+        }
+
+        [Test]
+        public void CompareIDictionaryImplementationAsObject()
+        {
+            object firstDictionary = new StringDictionary
+            {
+                {"Key", "Value"},
+                {"AnotherKey", "Value"},
+            };
+
+            object secondDictionary = new StringDictionary
+            {
+                {"Key", "Value"},
+                {"AnotherKey", "AnotherValue"},
+            };
+
+            firstDictionary.DeeplyEquals(secondDictionary)[0].Should()
+                .Be(new Distinction("StringDictionary[AnotherKey]", "Value", "AnotherValue"));
+        }
     }
 }

--- a/ObjectComparator/Comparator/Strategies/Implementations/Collections/CollectionsCompareStrategy.cs
+++ b/ObjectComparator/Comparator/Strategies/Implementations/Collections/CollectionsCompareStrategy.cs
@@ -26,7 +26,7 @@ namespace ObjectsComparator.Comparator.Strategies.Implementations.Collections
 
         public override DeepEqualityResult Compare<T>(T expected, T actual, string propertyName)
         {
-            var genericType = GetGenericArgument(typeof(T));
+            var genericType = GetGenericArgument(expected?.GetType() ?? typeof(T));
             var compareCollectionsMethod = CompareCollectionsMethod.MakeGenericMethod(genericType);
             return CollectionHelper.GetDelegateFor(compareCollectionsMethod)(expected, actual,
                 propertyName, RulesHandler);

--- a/ObjectComparator/Comparator/Strategies/Implementations/Collections/DictionaryCompareStrategy.cs
+++ b/ObjectComparator/Comparator/Strategies/Implementations/Collections/DictionaryCompareStrategy.cs
@@ -39,7 +39,7 @@ public class DictionaryCompareStrategy : BaseCollectionsCompareStrategy
 
     public override DeepEqualityResult Compare<T>(T expected, T actual, string propertyName)
     {
-        var genericArguments = GetGenericArguments(typeof(T));
+        var genericArguments = GetGenericArguments(expected?.GetType() ?? typeof(T));
         return (DeepEqualityResult)CompareMethod.MakeGenericMethod(genericArguments)
             .Invoke(this, new[] { (object)expected, actual, propertyName })!;
     }


### PR DESCRIPTION
First of all, I appreciate your efforts in developing ObjectComparator.
I love the output shown by ObjectComparator much easier to identify differences than [ObjectsComparer](https://github.com/ValeraT1982/ObjectsComparer).

Anyway, this PR will fix the issue that ObjectComparator throws an InvalidOperationException when comparing collections as values of `object`,

```csharp
object act = new[] { "A", "B" };
object exp = new[] { "B", "C" };
exp.DeeplyEquals(act);
```

This comparison throws the following InvalidOperationException. The comparison between dictionaries also causes a similar error.
```csharp
System.InvalidOperationException : Sequence contains no elements
    Stack Trace:
       at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
   at ObjectsComparator.Comparator.Strategies.Implementations.Collections.CollectionsCompareStrategy.GetGenericArgument(Type type) in c:\OneDrive\home\ObjectComparator\ObjectComparator\Comparator\Strategies\Implementations\Collections\CollectionsCompareStrategy.cs:line 37
   at ObjectsComparator.Comparator.Strategies.Implementations.Collections.CollectionsCompareStrategy.Compare[T](T expected, T actual, String propertyName) in c:\OneDrive\home\ObjectComparator\ObjectComparator\Comparator\Strategies\Implementations\Collections\CollectionsCompareStrategy.cs:line 29
   at ObjectsComparator.Comparator.Rules.CompareValues.Compare[T](T expected, T actual, String propertyName) in c:\OneDrive\home\ObjectComparator\ObjectComparator\Comparator\Rules\CompareValues.cs:line 42
   at ObjectsComparator.Comparator.Comparator.Compare[T](T expected, T actual) in c:\OneDrive\home\ObjectComparator\ObjectComparator\Comparator\Comparator.cs:line 47
```

The CollectionsCompareStrategy failed to get the element type because it treated the values as `object`.
This PR fixes this behavior.