### PR TITLE
Add README section for comparing different object types

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ ObjectComparator is a high-performance .NET library designed for deep comparison
   - [DeeplyEquals when Equality Operator Is Overridden](#deeplyequals-when-equality-operator-is-overridden)
   - [Display Distinctions for Dictionary Types](#display-distinctions-for-dictionary-types)
   - [Comparison for Anonymous Types](#comparison-for-anonymous-types)
+  - [Comparison for Different Types](#comparison-for-different-types)
   - [Convert Comparison Result to JSON](#convert-comparison-result-to-json)
   - [Configuring the Comparison Pipeline](#configuring-the-comparison-pipeline)
 - [Working with the Source](#working-with-the-source)
@@ -409,6 +410,35 @@ var result = exp.DeeplyEquals(act);
     Path: "AnonymousType<Int32, String, Byte[]>.Nested[2]":
     Expected Value :3
     Actually Value :4
+*/
+```
+
+### Comparison for Different Types
+
+Compare objects with different types that share the same shape or property names.
+
+```csharp
+var expected = new LegacyStudent
+{
+    Name = "Alex",
+    Age = 20
+};
+
+var actual = new Student
+{
+    Name = "Alex",
+    Age = 21
+};
+
+var result = expected.DeeplyEquals(actual, options => options.AllowDifferentTypes());
+
+// Or use the convenience overload:
+var result2 = expected.DeeplyEqualsIgnoreObjectTypes(actual);
+
+/*
+    Path: "LegacyStudent.Age":
+    Expected Value: 20
+    Actual Value: 21
 */
 ```
 


### PR DESCRIPTION
### Motivation
- Provide documentation for comparing objects that have different runtime types but compatible shapes.
- Show how to enable cross-type comparisons via options and a convenience overload to improve discoverability.
- Update the table of contents so the new topic is easier to find.

### Description
- Added a TOC entry for `Comparison for Different Types` and a new section in `README.md` demonstrating the feature.
- Documented using `options => options.AllowDifferentTypes()` to allow comparing objects of different types.
- Included a convenience example showing the `DeeplyEqualsIgnoreObjectTypes` overload.
- Provided a short code snippet that shows a difference being reported for the `Age` property when comparing `LegacyStudent` and `Student`.

### Testing
- No automated tests were run as this is a documentation-only change.
- `dotnet test` was not executed for this PR because there are no code changes affecting behavior.
- No CI status updates were triggered by these documentation edits.
- Manual validation consisted of verifying the README content and table-of-contents entries render correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e3919d4bc8321b3ec9742dd046334)